### PR TITLE
Added update on player board when opponent missed

### DIFF
--- a/src/main/java/com/battleship/gui/GameBoard.java
+++ b/src/main/java/com/battleship/gui/GameBoard.java
@@ -406,6 +406,7 @@ public class GameBoard {
             setScoreLabel();
         } else {
             // not hit, it's this players turn now
+            updateMissedBoard(posToAttack);
             isUserTurn = true;
             setTurnLabel();
         }
@@ -434,6 +435,11 @@ public class GameBoard {
         playerPositions[posToAttack[1]][posToAttack[2]].setEnabled(false);
         PowerUp.handlePowerUp(playerPositions, posToAttack, ColorPack.playerHitColor);
         checkForWinAndSendData(posToAttack);
+    }
+
+    private void updateMissedBoard(int[] posToAttack) {
+        playerPositions[posToAttack[1]][posToAttack[2]].setBackground(Color.GRAY);
+        playerPositions[posToAttack[1]][posToAttack[2]].setEnabled(false);
     }
 
     /**


### PR DESCRIPTION
A missed shot by opponent will now show gray square on player board. Allowing for more dynamic view of game